### PR TITLE
feat: add label line height in core

### DIFF
--- a/core/src/toga/style/applicator.py
+++ b/core/src/toga/style/applicator.py
@@ -56,6 +56,9 @@ class TogaApplicator:
     def set_text_align(self, alignment: str) -> None:
         self.widget._impl.set_text_align(alignment)
 
+    def set_line_height(self, line_height: int) -> None:
+        self.widget._impl.set_line_height(line_height)
+
     def set_hidden(self, hidden: bool) -> None:
         self.widget._impl.set_hidden(hidden)
         for child in self.widget.children:

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -100,6 +100,8 @@ class Pack(BaseStyle):
 
     text_align: str | None = validated_property(LEFT, RIGHT, CENTER, JUSTIFY)
     text_direction: str | None = validated_property(RTL, LTR, initial=LTR)
+    
+    line_height: int | None = validated_property(integer=True, initial=20)
 
     font_family: str = validated_property(
         *SYSTEM_DEFAULT_FONTS, string=True, initial=SYSTEM
@@ -287,6 +289,8 @@ class Pack(BaseStyle):
                                 break
 
                     self._applicator.set_hidden(value == HIDDEN)
+                elif name == "line_height":
+                    self._applicator.set_line_height(self.line_height)
                 elif name in (
                     "font_family",
                     "font_size",
@@ -918,6 +922,10 @@ class Pack(BaseStyle):
         # text_align
         if self.text_align:
             css.append(f"text-align: {self.text_align};")
+
+        # line_height
+        if self.line_height:
+            css.append(f"line-height: {self.line_height};")
 
         # text_direction
         if self.text_direction != LTR:


### PR DESCRIPTION
The label line height was implemented by changing the style class. The default line height is now set as 20 pixels (because it does not seem as if the font size can change so 20 was suitable). 

To create a label with e.g. two rows and line height 50p, write toga.Label("Label_text_row_1\nrow_2", style=Pack(line_height=50)). 

fixes #2 