### PR TITLE
feat: add line height for labels in Windows backend

### DIFF
--- a/core/src/toga/style/applicator.py
+++ b/core/src/toga/style/applicator.py
@@ -56,6 +56,9 @@ class TogaApplicator:
     def set_text_align(self, alignment: str) -> None:
         self.widget._impl.set_text_align(alignment)
 
+    def set_line_height(self, line_height: int) -> None:
+        self.widget._impl.set_line_height(line_height)
+
     def set_hidden(self, hidden: bool) -> None:
         self.widget._impl.set_hidden(hidden)
         for child in self.widget.children:

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -100,6 +100,8 @@ class Pack(BaseStyle):
 
     text_align: str | None = validated_property(LEFT, RIGHT, CENTER, JUSTIFY)
     text_direction: str | None = validated_property(RTL, LTR, initial=LTR)
+    
+    line_height: int | None = validated_property(integer=True, initial=20)
 
     font_family: str = validated_property(
         *SYSTEM_DEFAULT_FONTS, string=True, initial=SYSTEM
@@ -287,6 +289,8 @@ class Pack(BaseStyle):
                                 break
 
                     self._applicator.set_hidden(value == HIDDEN)
+                elif name == "line_height":
+                    self._applicator.set_line_height(self.line_height)
                 elif name in (
                     "font_family",
                     "font_size",
@@ -918,6 +922,10 @@ class Pack(BaseStyle):
         # text_align
         if self.text_align:
             css.append(f"text-align: {self.text_align};")
+
+        # line_height
+        if self.line_height:
+            css.append(f"line-height: {self.line_height};")
 
         # text_direction
         if self.text_direction != LTR:

--- a/winforms/src/toga_winforms/widgets/label.py
+++ b/winforms/src/toga_winforms/widgets/label.py
@@ -1,6 +1,7 @@
 from decimal import ROUND_UP
 
 import System.Windows.Forms as WinForms
+from System.Drawing import SolidBrush, PointF
 from travertino.size import at_least
 
 from toga.colors import TRANSPARENT
@@ -8,26 +9,43 @@ from toga_winforms.libs.fonts import TextAlignment
 
 from .base import Widget
 
-
 class Label(Widget):
     def create(self):
         self.native = WinForms.Label()
         self._default_background_color = TRANSPARENT
-        self.native.AutoSizeMode = WinForms.AutoSizeMode.GrowAndShrink
+        self.native.Text = ""  
+        self.native.Paint += self.custom_paint
 
     def set_text_align(self, value):
-        self.native.TextAlign = TextAlignment(value)
+        self.text_align = value
+
+    def set_line_height(self, value):
+        self.line_height = value
 
     def get_text(self):
         return self.native.Text
 
     def set_text(self, value):
-        self.native.Text = value
+        self.custom_text = value
+        self.update_size()
 
     def rehint(self):
         self.interface.intrinsic.width = self.scale_out(
             at_least(self.native.PreferredSize.Width), ROUND_UP
         )
         self.interface.intrinsic.height = self.scale_out(
-            self.native.PreferredSize.Height, ROUND_UP
+            self.native.Height, ROUND_UP
         )
+
+    def update_size(self):
+        num_lines = self.custom_text.count("\n") + 1 
+        new_height = num_lines * self.line_height  
+        self.native.Height = new_height 
+
+    def custom_paint(self, _, e):
+        brush = SolidBrush(self.native.ForeColor)
+        y = 0
+
+        for line in self.custom_text.split("\n"):
+            e.Graphics.DrawString(line, self.native.Font, brush, PointF(0, y))
+            y += self.line_height 


### PR DESCRIPTION
To achive the line height in Winforms, the label text was manually written and any choice of text alignment is not accounted for. As for right now every label has text alignment in the upper left corner. This should be fixed so I'll open another issue for this

fixes #3 